### PR TITLE
Some performance improvements for larger amount of values

### DIFF
--- a/lib/tdms_parser/state.ex
+++ b/lib/tdms_parser/state.ex
@@ -40,9 +40,14 @@ defmodule TDMS.Parser.State do
     %{state | paths: Map.put(state.paths, path, result)}
   end
 
+  def get_data(state, path) do
+    result = state.paths[path]
+    List.flatten(result.data)
+  end
+
   def add_data(state, path, data) do
     result = state.paths[path]
-    result = %{result | data: result.data ++ data}
+    result = %{result | data: [result.data | data]}
 
     %{
       state
@@ -50,7 +55,11 @@ defmodule TDMS.Parser.State do
     }
   end
 
+  def get_raw_data_indexes(state) do
+    Enum.reverse(state.raw_data_indexes)
+  end
+
   def add_raw_data_index(state, raw_data_index) do
-    %{state | raw_data_indexes: state.raw_data_indexes ++ [raw_data_index]}
+    %{state | raw_data_indexes: [raw_data_index | state.raw_data_indexes]}
   end
 end


### PR DESCRIPTION
Removed a couple of list concatenations which speeds up the
parsing of larger TDMS files with many values or objects.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/tdms-parser/blob/master/CONTRIBUTING.md).
